### PR TITLE
修复账号内容空导致的cannot unpack non-iterable NoneType object错误

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -56,3 +56,4 @@ async def parse_last_dynamic(dyn: dict, data: dict):
                     ls.append(Image.fromURL(pic["url"]))
 
             return CommandResult(chain=ls).use_t2i(False), dyn_id
+    return None, None


### PR DESCRIPTION
小透明账号无有效动态时处理会报错：
```
[10:02:57| ERROR] [core_lifecycle.py:102]: ------- 任务 dynamic_listener 发生错误: cannot unpack non-iterable NoneType object 
[10:02:57| ERROR] [core_lifecycle.py:104]: | Traceback (most recent call last): 
[10:02:57| ERROR] [core_lifecycle.py:104]: | File "/AstrBot/astrbot/core/core_lifecycle.py", line 97, in _task_wrapper 
[10:02:57| ERROR] [core_lifecycle.py:104]: | await task 
[10:02:57| ERROR] [core_lifecycle.py:104]: | File "/AstrBot/data/plugins/astrbot_plugin_bilibili/main.py", line 281, in dynamic_listener 
[10:02:57| ERROR] [core_lifecycle.py:104]: | raise e 
[10:02:57| ERROR] [core_lifecycle.py:104]: | File "/AstrBot/data/plugins/astrbot_plugin_bilibili/main.py", line 234, in dynamic_listener 
[10:02:57| ERROR] [core_lifecycle.py:104]: | ret, dyn_id = await parse_last_dynamic(dyn, uid_sub_data) 
[10:02:57| ERROR] [core_lifecycle.py:104]: | TypeError: cannot unpack non-iterable NoneType object 
[10:02:57| ERROR] [core_lifecycle.py:104]: |
[10:02:57| ERROR] [core_lifecycle.py:105]: -------
```

解决办法为返回None, None