### PR TITLE
feat: add bilibili dynamics AI summary support

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -90,5 +90,17 @@
         "type": "text",
         "hint": "非图片推送模式下的转发内容模板，留空使用默认格式。可用变量: {name} {uid} {title} {text} {url}，数据来源为被转发的原动态。",
         "default": ""
+    },
+    "enable_ai_summary": {
+        "description": "enable_ai_summary",
+        "type": "bool",
+        "hint": "是否在动态推送后额外调用 AI 生成摘要",
+        "default": false
+    },
+    "ai_summary_prompt": {
+        "description": "ai_summary_prompt",
+        "type": "text",
+        "hint": "可选，AI 摘要提示词模板。可使用 {content} 代表组装后的动态内容。留空使用内置默认提示词。",
+        "default": ""
     }
 }

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from .services.subscription_service import SubscriptionService
 from .tools.bgm_daily import BgmDailyTool
 from .tools.bgm_subject import BgmAdvancedSubjectSearchTool, BgmRecommendHotSubjectsTool
 from .tools.bili_hot_video import BiliSearchHotVideosTool
+from .tools.bili_user_dynamics import BiliUserDynamicsTool
 
 
 @register("astrbot_plugin_bilibili", "Soulter", "", "", "")
@@ -110,6 +111,10 @@ class Main(Star):
             ),
             BiliSearchHotVideosTool(
                 bili_client=self.bili_client,
+            ),
+            BiliUserDynamicsTool(
+                bili_client=self.bili_client,
+                parse_dynamics=self.dynamic_listener._parse_and_filter_dynamics,
             ),
         )
         self.context.add_llm_tools(*llm_tools)

--- a/services/listener.py
+++ b/services/listener.py
@@ -7,7 +7,14 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from astrbot.api import logger
 from astrbot.api.all import *
-from astrbot.api.message_components import AtAll, File, Image, Plain
+from astrbot.api.event import MessageEventResult
+from astrbot.api.message_components import AtAll, File, Image, Node, Plain
+from astrbot.core.agent.message import (
+    AssistantMessageSegment,
+    ImageURLPart,
+    TextPart,
+    UserMessageSegment,
+)
 
 from ..bili_client import BiliClient
 from ..core.constant import BANNER_PATH, LOGO_PATH
@@ -70,6 +77,8 @@ class DynamicListener:
         self.plain_push_forward_template = (
             cfg.get("plain_push_forward_template", "") or ""
         ).strip()
+        self.enable_ai_summary = bool(cfg.get("enable_ai_summary", False))
+        self.ai_summary_prompt = (cfg.get("ai_summary_prompt", "") or "").strip()
 
     async def start(self):
         """启动后台监听循环（按 UID 任务池调度）。"""
@@ -381,6 +390,202 @@ class DynamicListener:
         )
         await self.dispatcher.publish(notification)
 
+    def _build_analysis_lines(self, payload: Any, nested: bool = False) -> List[str]:
+        lines = list(
+            filter(
+                None,
+                [
+                    f"作者: {getattr(payload, 'name', '') or '未知'}",
+                    f"类型: {getattr(payload, 'type', '') or '未知'}",
+                    (
+                        f"标题: {getattr(payload, 'title', '')}"
+                        if getattr(payload, "title", "")
+                        else ""
+                    ),
+                    render_text_to_plain(getattr(payload, "text", "") or ""),
+                    (
+                        f"链接: {getattr(payload, 'url', '')}"
+                        if getattr(payload, "url", "") and not nested
+                        else ""
+                    ),
+                ],
+            )
+        )
+        forward_data = getattr(payload, "forward", None)
+        if forward_data:
+            lines.append("转发原文:")
+            lines.extend(self._build_analysis_lines(forward_data, nested=True))
+        return lines
+
+    def _build_ai_summary_prompt(self, payload: Any) -> str:
+        content = "\n".join(self._build_analysis_lines(payload))
+        if self.ai_summary_prompt:
+            return self.ai_summary_prompt.format(content=content)
+        return (
+            "请根据下面这条 Bilibili 动态生成简洁中文总结。\n"
+            "要求：\n"
+            "1. 先用 1 句话概括动态在说什么。\n"
+            "2. 再列 2 到 4 条要点。\n"
+            "3. 如果能明显看出作者语气或目的，用 1 句话补充。\n"
+            "4. 不要编造未提供的信息，不要使用 Markdown 标题。\n\n"
+            f"{content}"
+        )
+
+    async def _get_image_captions(
+        self, image_urls: list[str], sub_user: str
+    ) -> list[str] | None:
+        astrbot_cfg = self.context.get_config()
+        provider_settings = astrbot_cfg.get("provider_settings", {})
+        caption_provider_id = (
+            provider_settings.get("default_image_caption_provider_id") or ""
+        ).strip()
+        if not caption_provider_id or not image_urls:
+            return None
+
+        caption_prompt = provider_settings.get(
+            "image_caption_prompt", "Please describe the image using Chinese."
+        )
+        provider_mgr = getattr(self.context, "provider_manager", None)
+        if not provider_mgr:
+            return None
+
+        caption_provider = await provider_mgr.get_provider_by_id(caption_provider_id)
+        if not caption_provider:
+            logger.warning("图片转述模型 %s 未找到，跳过转述。", caption_provider_id)
+            return None
+
+        captions = []
+        for img_url in image_urls:
+            try:
+                resp = await caption_provider.text_chat(
+                    prompt=caption_prompt,
+                    image_urls=[img_url],
+                )
+                cap = (getattr(resp, "completion_text", "") or "").strip()
+                if cap:
+                    captions.append(cap)
+                    logger.info("图片转述成功: %s -> %s", img_url[:60], cap[:80])
+            except Exception as e:
+                logger.warning("图片转述失败 %s: %s", img_url[:60], e)
+                captions.append("")
+        return captions
+
+    async def _generate_ai_summary(self, sub_user: str, payload: Any) -> str:
+        if not self.enable_ai_summary:
+            return ""
+
+        provider_getter = getattr(self.context, "get_current_chat_provider_id", None)
+        llm_generate = getattr(self.context, "llm_generate", None)
+        if not callable(provider_getter) or not callable(llm_generate):
+            logger.warning("当前 AstrBot 版本不支持插件内直接调用 LLM，已跳过动态摘要。")
+            return ""
+
+        try:
+            provider_id = await provider_getter(umo=sub_user)
+            if not provider_id:
+                logger.info("会话 %s 未配置聊天模型，已跳过动态摘要。", sub_user)
+                return ""
+
+            image_urls = [
+                url.strip().replace("http://", "https://")
+                for url in getattr(payload, "image_urls", []) or []
+                if isinstance(url, str) and url.strip()
+                and not url.startswith("data:")
+            ][:8]
+
+            prompt_text = self._build_ai_summary_prompt(payload)
+
+            captions = await self._get_image_captions(image_urls, sub_user)
+
+            if captions:
+                caption_lines = "\n".join(
+                    f"[图片 {i+1}]: {c}" for i, c in enumerate(captions) if c
+                )
+                if caption_lines:
+                    prompt_text = f"{prompt_text}\n\n该动态包含以下图片：\n{caption_lines}"
+                logger.info(
+                    "AI摘要: 使用图片转述, prompt_len=%d, images=%d, captions=%d",
+                    len(prompt_text),
+                    len(image_urls),
+                    len(captions),
+                )
+                llm_resp = await llm_generate(
+                    chat_provider_id=provider_id,
+                    contexts=[
+                        UserMessageSegment(content=[TextPart(text=prompt_text)])
+                    ],
+                )
+            else:
+                user_parts: list = [TextPart(text=prompt_text)]
+                for idx, img_url in enumerate(image_urls, start=1):
+                    user_parts.append(
+                        ImageURLPart(
+                            image_url=ImageURLPart.ImageURL(
+                                url=img_url, id=f"dynamic-{idx}"
+                            )
+                        )
+                    )
+                logger.info(
+                    "AI摘要: 构造显式多模态消息, prompt_len=%d, images=%d, urls=%s",
+                    len(prompt_text),
+                    len(image_urls),
+                    image_urls,
+                )
+                llm_resp = await llm_generate(
+                    chat_provider_id=provider_id,
+                    contexts=[UserMessageSegment(content=user_parts)],
+                )
+
+            return (getattr(llm_resp, "completion_text", "") or "").strip()
+        except Exception as e:
+            logger.error("生成动态 AI 摘要失败: %s\n%s", e, traceback.format_exc())
+            return ""
+
+    async def _persist_ai_summary(
+        self, sub_user: str, payload: Any, summary_text: str
+    ) -> None:
+        conv_mgr = getattr(self.context, "conversation_manager", None)
+        if conv_mgr is None:
+            return
+        try:
+            cid = await conv_mgr.get_curr_conversation_id(sub_user)
+            if not cid:
+                return
+
+            user_parts: list = [TextPart(text=self._build_ai_summary_prompt(payload))]
+            for index, image_url in enumerate(
+                [
+                    url.strip().replace("http://", "https://")
+                    for url in getattr(payload, "image_urls", []) or []
+                    if isinstance(url, str) and url.strip()
+                    and not url.startswith("data:")
+                ][:8],
+                start=1,
+            ):
+                user_parts.append(
+                    ImageURLPart(
+                        image_url=ImageURLPart.ImageURL(url=image_url, id=f"dynamic-{index}")
+                    )
+                )
+
+            await conv_mgr.add_message_pair(
+                cid=cid,
+                user_message=UserMessageSegment(content=user_parts),
+                assistant_message=AssistantMessageSegment(content=summary_text),
+            )
+        except Exception as e:
+            logger.error("写入动态摘要到会话历史失败: %s\n%s", e, traceback.format_exc())
+
+    async def _send_ai_summary(self, sub_user: str, payload: Any) -> None:
+        summary_text = await self._generate_ai_summary(sub_user, payload)
+        if not summary_text:
+            return
+        await self._persist_ai_summary(sub_user, payload, summary_text)
+        await self.context.send_message(
+            sub_user,
+            MessageEventResult(chain=[Plain(f"AI 总结:\n{summary_text}")]).use_t2i(False),
+        )
+
     def _cache_render(self, dyn_id: Optional[str], chain_parts: list, send_node: bool):
         """缓存渲染结果，避免同一动态在不同会话重复渲染。"""
         if not dyn_id:
@@ -409,6 +614,7 @@ class DynamicListener:
                 category="dynamic",
                 dyn_id=dyn_id,
             )
+            await self._send_ai_summary(sub_user, payload)
             return
 
         send_node_flag = self.node
@@ -425,6 +631,7 @@ class DynamicListener:
                 dyn_id=dyn_id,
             )
             self._cache_render(dyn_id, ls, send_node_flag)
+            await self._send_ai_summary(sub_user, payload)
             logger.info(f"动态推送完成(纯文本): sub_user={sub_user} dyn_id={dyn_id}")
             return
 
@@ -446,6 +653,7 @@ class DynamicListener:
                 dyn_id=dyn_id,
             )
             self._cache_render(dyn_id, ls, send_node_flag)
+            await self._send_ai_summary(sub_user, payload)
             logger.info(f"动态推送完成(图片): sub_user={sub_user} dyn_id={dyn_id}")
             return
 
@@ -459,6 +667,7 @@ class DynamicListener:
         await self._send_dynamic(
             sub_user, ls, send_node=True, category="dynamic", dyn_id=dyn_id
         )
+        await self._send_ai_summary(sub_user, payload)
         logger.info(f"动态推送完成(降级纯文本): sub_user={sub_user} dyn_id={dyn_id}")
 
     @staticmethod

--- a/tools/bili_user_dynamics.py
+++ b/tools/bili_user_dynamics.py
@@ -1,0 +1,154 @@
+from datetime import datetime
+from typing import Any
+
+from astrbot.api import FunctionTool
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.astr_agent_context import AstrAgentContext
+from mcp.types import CallToolResult
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from ..core.models import SubscriptionRecord
+from ..core.utils import render_text_to_plain
+
+DEFAULT_LIMIT = 3
+MIN_LIMIT = 1
+MAX_LIMIT = 10
+
+
+def _normalize_limit(limit: int) -> int:
+    if limit < MIN_LIMIT:
+        return MIN_LIMIT
+    if limit > MAX_LIMIT:
+        return MAX_LIMIT
+    return limit
+
+
+def _extract_pub_time(item: dict[str, Any]) -> str:
+    author = item.get("modules", {}).get("module_author", {})
+    if not isinstance(author, dict):
+        return "未知时间"
+    pub_time = author.get("pub_time")
+    if isinstance(pub_time, str) and pub_time.strip():
+        return pub_time.strip()
+    pub_ts = author.get("pub_ts")
+    if isinstance(pub_ts, int) and pub_ts > 0:
+        return datetime.fromtimestamp(pub_ts).strftime("%Y-%m-%d %H:%M:%S")
+    return "未知时间"
+
+
+def _payload_main_text(payload: Any) -> str:
+    summary = (getattr(payload, "summary", "") or "").strip()
+    if summary:
+        return summary
+    return render_text_to_plain(getattr(payload, "text", "") or "").strip()
+
+
+def _format_dynamic_block(index: int, payload: Any, pub_time: str) -> str:
+    lines = [
+        f"{index}. 类型: {getattr(payload, 'type', '') or '未知类型'}",
+        f"发布时间: {pub_time}",
+    ]
+
+    title = (getattr(payload, "title", "") or "").strip()
+    if title:
+        lines.append(f"标题: {title}")
+
+    main_text = _payload_main_text(payload)
+    if main_text:
+        lines.append(f"正文: {main_text}")
+
+    forward = getattr(payload, "forward", None)
+    if forward:
+        forward_text = _payload_main_text(forward)
+        if forward_text:
+            lines.append(f"转发原文: {forward_text}")
+
+    url = (getattr(payload, "url", "") or "").strip()
+    if url:
+        lines.append(f"链接: {url}")
+
+    return "\n".join(lines)
+
+
+@dataclass
+class BiliUserDynamicsTool(FunctionTool):
+    name: str = "bili_get_user_dynamics"
+    description: str = (
+        "当用户想查询某个 Bilibili UP 主最近动态、让你总结近期发文内容、"
+        "分析动态主题或语气时调用。输入 UID，返回最近几条动态的结构化文本。"
+    )
+    bili_client: Any = None
+    parse_dynamics: Any = None
+    parameters: dict = Field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "integer",
+                    "description": "要查询的 Bilibili 用户 UID。",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "返回动态条数，范围 1-10，默认 3。",
+                    "minimum": MIN_LIMIT,
+                    "maximum": MAX_LIMIT,
+                },
+            },
+            "required": ["uid"],
+        }
+    )
+
+    async def call(
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        uid: int,
+        limit: int = DEFAULT_LIMIT,
+    ) -> str | CallToolResult:
+        _ = context
+        if self.bili_client is None or self.parse_dynamics is None:
+            raise RuntimeError("bilibili dynamics tool 未正确初始化")
+
+        normalized_limit = _normalize_limit(limit)
+        user_info, _ = await self.bili_client.get_user_info(int(uid))
+        dynamics = await self.bili_client.get_latest_dynamics(int(uid))
+
+        if not dynamics:
+            return "获取该 UP 主动态失败，可能是未登录、UID 无效，或 B 站接口暂时不可用。"
+
+        parsed_results = self.parse_dynamics(
+            dynamics,
+            SubscriptionRecord(uid=int(uid)),
+        )
+
+        payload_blocks: list[str] = []
+        for result, item in zip(parsed_results, dynamics.get("items", []), strict=False):
+            if not result.has_payload():
+                continue
+            payload_blocks.append(
+                _format_dynamic_block(
+                    len(payload_blocks) + 1,
+                    result.payload,
+                    _extract_pub_time(item),
+                )
+            )
+            if len(payload_blocks) >= normalized_limit:
+                break
+
+        if not payload_blocks:
+            return "该 UP 主最近没有可解析的动态，或者动态都被过滤屏蔽了。"
+
+        up_name = "未知UP"
+        if isinstance(user_info, dict):
+            up_name = str(user_info.get("name", "") or up_name)
+
+        lines = [
+            f"UP主: {up_name}",
+            f"UID: {uid}",
+            f"最近动态共返回 {len(payload_blocks)} 条。",
+            "",
+            *payload_blocks,
+            "",
+            "请基于以上动态内容回答，不要编造未提供的信息。",
+        ]
+        return "\n".join(lines)


### PR DESCRIPTION
## 改动内容

- 新增 `enable_ai_summary` 和 `ai_summary_prompt` 配置项
- 动态推送后支持调用 LLM 生成 AI 摘要并发送
- 支持图片转述（image caption provider）实现多模态摘要
- 新增 `bili_get_user_dynamics` LLM tool，支持查询 UP 主最近动态
- 适配 `feat/silent-reconnect` 的 dispatcher 消息发送机制

## 测试

- `/bili_sub_test` 命令可验证动态推送 + AI 摘要功能