### PR TITLE
fix: handle "<br>" correctly when render-as-image disabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,6 +224,7 @@ class Main(Star):
     async def _send_subscription_result(
         self, event: AstrMessageEvent, payload: RenderPayload, avatar: str
     ) -> MessageEventResult | None:
+        text = "\n".join(filter(None, payload.text.split("<br>")))
         if self.rai:
             img_path = await self.renderer.render_dynamic(payload)
             if img_path:
@@ -232,13 +233,12 @@ class Main(Star):
                 )
                 return None
             msg = "渲染图片失败了 (´;ω;`)"
-            text = "\n".join(filter(None, payload.text.split("<br>")))
             chain = MessageChain().message(msg).message(text)
             if avatar:
                 chain = chain.url_image(avatar)
             await event.send(chain)
             return None
-        chain = [Plain(payload.text)]
+        chain = [Plain(text)]
         if avatar:
             chain.append(Image.fromURL(avatar))
         return MessageEventResult(chain=chain, use_t2i_=False)


### PR DESCRIPTION
当图片渲染推送为 false 时，订阅结果文本中的 HTML 换行符未正确处理

<img width="330" height="418" alt="b6feb75e564cf9ea3b4ef5b7f5022378" src="https://github.com/user-attachments/assets/d9fef514-2f0f-450b-a2c8-6c910c7bbc42" />
