### PR TITLE
修复直播通知始终显示“UP主 [AstrBot] 发布了新动态”

### DIFF
--- a/services/listener.py
+++ b/services/listener.py
@@ -796,9 +796,10 @@ class DynamicListener:
     def _build_live_payload(live_room: Dict[str, Any], text: str) -> RenderPayload:
         room_id = int(live_room.get("room_id", 0) or 0)
         link = f"https://live.bilibili.com/{room_id}"
+        user_name = str(live_room.get("uname", "Unknown") or "Unknown")
         return RenderPayload(
             banner=image_to_base64(BANNER_PATH),
-            name="AstrBot",
+            name=user_name,
             avatar=image_to_base64(LOGO_PATH),
             title=str(live_room.get("title", "Unknown") or "Unknown"),
             url=link,


### PR DESCRIPTION
问题现象：
如下图所示
<img width="408" height="735" alt="5f2192d0-5fee-4133-a6a9-b7210f5d3eb2" src="https://github.com/user-attachments/assets/a3c54e9c-b667-431f-9cba-b8fd0afd3616" />

问题根因：
1.直播动态文字渲染模板的name参数为固定值 AstrBot

修改方案：
1.通过live_room.get("uname", "Unknown")获取直播间主播名，再将其名字传递给文字渲染模板的name参数

自验截图：
<img width="421" height="342" alt="QQ_1781284925031" src="https://github.com/user-attachments/assets/18f04bd0-d80e-43f9-a2e4-f8210506e1cf" />
