### PR TITLE
fix(listener): 修复直播动态纯文本推送布局与相关问题

### DIFF
--- a/services/listener.py
+++ b/services/listener.py
@@ -6,8 +6,8 @@ from collections import OrderedDict, defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
 from astrbot.api import logger
-from astrbot.api.all import *
-from astrbot.api.message_components import AtAll, File, Image, Plain
+from astrbot.api.message_components import At, AtAll, File, Image, Plain
+from astrbot.core.star import Context
 from astrbot.core.agent.message import (
     AssistantMessageSegment,
     ImageURLPart,
@@ -284,18 +284,22 @@ class DynamicListener:
         if render_fail and not nested:
             chain.append(Plain("渲染图片失败了 (´;ω;`)\n"))
 
-        lines = list(
-            filter(
-                None,
-                [
-                    None
-                    if (category == "live" and not self.rai)
-                    else self._build_plain_header(payload, nested),
-                    (f"标题: {payload.title}" if payload.title else ""),
-                    self._build_plain_body(payload),
-                ],
-            )
-        )
+        header_item = self._build_plain_header(payload, nested)
+        title_item = f"标题: {payload.title}" if payload.title else ""
+        body_raw = self._build_plain_body(payload)
+
+        is_live_plain = category == "live" and not self.rai
+        if is_live_plain:
+            # 开播/下播通知不使用默认 header，用 body 第一行作为标题行，
+            # 直播间标题放在 body 中间，时长行（如果有）放在最后
+            header_item = None
+            body_lines = body_raw.split("\n")
+            notify_line = body_lines[0]  # "📣 ...开播了/下播了！"
+            tail_lines = body_lines[1:]  # ["本场直播时长：..."]
+            ordering = [notify_line, title_item, *tail_lines]
+            lines = list(filter(None, ordering))
+        else:
+            lines = list(filter(None, [header_item, title_item, body_raw]))
         if lines:
             chain.append(Plain("\n".join(lines)))
 
@@ -427,7 +431,7 @@ class DynamicListener:
     def _build_ai_summary_prompt(self, payload: Any) -> str:
         content = "\n".join(self._build_analysis_lines(payload))
         if self.ai_summary_prompt:
-            return self.ai_summary_prompt.format(content=content)
+            return self.ai_summary_prompt.replace("{content}", content)
         return (
             "请根据下面这条 Bilibili 动态生成简洁中文总结。\n"
             "要求：\n"
@@ -886,7 +890,7 @@ class DynamicListener:
                 )
             await self._send_dynamic(sub_user, image_chain, category="live")
             return
-        ls = self._compose_plain_push(payload, render_fail=True)
+        ls = self._compose_plain_push(payload, render_fail=True, category="live")
         if not is_offline:
             ls = self._add_at_components(
                 list(ls), sub_data, is_live=True, permit_atall=permit_atall


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
*   **Impact:** Medium - 提升了直播通知的阅读体验，并修复了特定场景下的报错。
*   **Key Changes:**
    *   ✨ **优化直播通知排版**：重构了直播开播/下播的纯文本推送格式，使标题、通知语和时长的顺序更加合理。
    *   🐛 **修复 Prompt 格式化异常**：将 AI 总结提示词的组装方式由 `.format()` 替换为 `.replace()`，避免提示词中包含大括号 `{}` 时引发解析错误。
    *   🐛 **修复推送降级传参**：修复了直播推送在图片渲染失败降级为纯文本时，未正确传递 `category="live"` 的问题。
    *   ♻️ **规范依赖导入**：移除了通配符导入（`import *`），改为按需引入组件库。

## 2. Visual Overview (Code & Logic Map)

以下图表展示了重构后的纯文本推送构建逻辑（`_compose_plain_push`），重点突出了针对“直播 (live)”类型的定制化排版：

```mermaid
graph TD
    Start["_compose_plain_push()"] --> Extract["提取基础元素: header_item, title_item, body_raw"]
    Extract --> Check{"是否为直播纯文本通知? <br>(category == 'live' & not rai)"}
    
    Check -- "Yes" --> SplitBody["拆分 body_raw"]
    SplitBody --> FormatLive["提取 notify_line (第一行)<br>提取 tail_lines (剩余行)"]
    FormatLive --> CombineLive["组合顺序: <br>1. notify_line<br>2. title_item<br>3. tail_lines"]
    
    Check -- "No" --> CombineNormal["组合顺序: <br>1. header_item<br>2. title_item<br>3. body_raw"]
    
    CombineLive --> Filter["过滤空行并拼接"]
    CombineNormal --> Filter
    Filter --> End["返回 Plain 组件"]

    style Check fill:#fff3e0,color:#e65100
    style CombineLive fill:#c8e6c9,color:#1a5e20
    style CombineNormal fill:#bbdefb,color:#0d47a1
```

## 3. Detailed Change Analysis

### 🎯 Listener 核心逻辑 (`services/listener.py`)

*   **直播通知排版优化 (`_compose_plain_push`)**: 
    废弃了原有的硬编码嵌套列表过滤逻辑。现在针对直播场景（开播/下播）特殊处理，将原有正文（`body_raw`）的首行（如 "📣 xxx开播了！"）作为头部，接着插入直播间标题，最后附加上时长等尾部信息，摒弃了默认的动态 `header`。
*   **Prompt 构建防错 (`_build_ai_summary_prompt`)**: 
    在替换自定义提示词中的 `{content}` 占位符时，使用字符串的 `.replace()` 方法代替 `.format()`。这对于需要编写包含 JSON 格式或特殊 `{}` 字符的高级 Prompt 的用户来说是必要的修复。
*   **降级推送修复 (第 890 行附近)**: 
    在下发直播通知前，如果进入了纯文本兜底逻辑（如关闭了图片渲染或渲染失败），调用 `_compose_plain_push` 时补充了缺失的 `category="live"` 参数。这使得兜底逻辑也能应用到上述的排版优化。

### 📦 依赖与命名空间调整

| 原导入 | 新导入 | 描述 |
| :--- | :--- | :--- |
| `from astrbot.api.all import *` | 移除 | 消除通配符导入，避免命名空间污染 |
| - | `from astrbot.api.message_components import At` | 显式导入 `At` 组件 |
| - | `from astrbot.core.star import Context` | 补充 `Context` 类型提示依赖 |

## 4. Impact & Risk Assessment
*   **⚠️ Breaking Changes:** 无。此更改完全向后兼容。
*   **🧪 Testing Suggestions:**
    *   **直播推送测试**: 模拟 B 站主播开播和下播，验证纯文本推送消息中的标题和内容顺序是否美观且符合预期。
    *   **兜底逻辑测试**: 强制关闭图片渲染 (`render_fail=True`)，触发开播通知，确认通知没有回退到丑陋的默认格式。
    *   **AI 总结测试**: 在后台配置中设置一个包含大量 `{` 和 `}` 的自定义 AI 总结提示词（例如 JSON 模板），验证调用大模型时不再报 `KeyError`。